### PR TITLE
Buff Spices

### DIFF
--- a/src/generated/resources/data/caupona/recipes/spice/asafoetida_spice_jar.json
+++ b/src/generated/resources/data/caupona/recipes/spice/asafoetida_spice_jar.json
@@ -3,7 +3,7 @@
   "effect": {
     "effect": "minecraft:resistance",
     "level": 0,
-    "time": 200
+    "time": 600
   },
   "reacts_lead": false,
   "spice": {

--- a/src/generated/resources/data/caupona/recipes/spice/garum_spice_jar.json
+++ b/src/generated/resources/data/caupona/recipes/spice/garum_spice_jar.json
@@ -2,8 +2,8 @@
   "type": "caupona:spice",
   "effect": {
     "effect": "minecraft:jump_boost",
-    "level": 0,
-    "time": 200
+    "level": 1,
+    "time": 600
   },
   "reacts_lead": false,
   "spice": {

--- a/src/generated/resources/data/caupona/recipes/spice/sapa_spice_jar.json
+++ b/src/generated/resources/data/caupona/recipes/spice/sapa_spice_jar.json
@@ -3,7 +3,7 @@
   "effect": {
     "effect": "caupona:hyperactive",
     "level": 0,
-    "time": 200
+    "time": 600
   },
   "reacts_lead": false,
   "spice": {

--- a/src/generated/resources/data/caupona/recipes/spice/sugar_spice_jar.json
+++ b/src/generated/resources/data/caupona/recipes/spice/sugar_spice_jar.json
@@ -3,7 +3,7 @@
   "effect": {
     "effect": "minecraft:speed",
     "level": 0,
-    "time": 200
+    "time": 600
   },
   "reacts_lead": false,
   "spice": {

--- a/src/generated/resources/data/caupona/recipes/spice/vinegar_spice_jar.json
+++ b/src/generated/resources/data/caupona/recipes/spice/vinegar_spice_jar.json
@@ -3,7 +3,7 @@
   "effect": {
     "effect": "minecraft:night_vision",
     "level": 0,
-    "time": 200
+    "time": 600
   },
   "reacts_lead": true,
   "spice": {


### PR DESCRIPTION
I feel like a lot of spices are way too weak to really be that worthwhile.

In order to use a spice, you have to:

-Have the Spice Jar, which also takes durability
-Carry around an unstackable stew
-Eat the stew, which takes a couple of seconds to do, and you can't sprint during that
and all you get out of that is a 10 second potion effect.
Most of the effects of spices are more useful reactionary anyways, but the time it takes to eat, and the unstackable nature of stews, makes the very short effect almost never useful. Why would I ever spend several seconds eating a stew, just to deal double damage for 10 seconds, when i could just hit the enemy a few times during that time instead?



This pull request:
-makes all spices except for chives last for 30 seconds, instead of 10
I feel like slow falling is the only one of these, which is actually useful for the short amount of time it gives you. I think it is fine right now, but if you want to buff it to 30 seconds as well, go ahead.

-makes Garum give jump boost II instead of jump boost I
jump boost 1 is pretty much useless. It increases your jump height to 1.5, which is pretty much only useful if you are for some reason encountering slabs or fences. Which would pretty much never happen. Jump boost II, which increases your jump height to two blocks, is actually useful.