### PR TITLE
Make Charcoal with Caupona Logs

### DIFF
--- a/src/generated/resources/data/minecraft/tags/items/logs_that_burn.json
+++ b/src/generated/resources/data/minecraft/tags/items/logs_that_burn.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "caupona:walnut_wood",
+    "caupona:walnut_log",
+    "caupona:stripped_walnut_wood",
+    "caupona:stripped_walnut_log",
+    "caupona:fig_log",
+    "caupona:wolfberry_log"
+  ]
+}


### PR DESCRIPTION
Caupona logs are not currently in the #minecraft:logs_that_burn tag, which means that they are not smeltable into charcoal. This pull request adds them to said tag, allowing for creating charcoal from them in a furnace.